### PR TITLE
Step12 선택한 동시성 제어 방식을 통한 통합 테스트 추가

### DIFF
--- a/src/main/java/org/lowell/concert/application/payment/PaymentFacade.java
+++ b/src/main/java/org/lowell/concert/application/payment/PaymentFacade.java
@@ -40,7 +40,7 @@ public class PaymentFacade {
         reservation.isReservableStatus();
 
         LocalDateTime paymentTime = LocalDateTime.now();
-        ConcertSeat concertSeat = concertSeatService.getConcertSeatWithLock(new ConcertSeatQuery.Search(reservation.getSeatId()));
+        ConcertSeat concertSeat = concertSeatService.getConcertSeat(new ConcertSeatQuery.Search(reservation.getSeatId()));
         concertSeat.checkPayableSeat(paymentTime, ConcertPolicy.TEMP_RESERVED_SEAT_MINUTES);
         concertSeat.reserveSeat(paymentTime);
 

--- a/src/main/java/org/lowell/concert/application/user/UserFacade.java
+++ b/src/main/java/org/lowell/concert/application/user/UserFacade.java
@@ -37,4 +37,16 @@ public class UserFacade {
                                         userAccount.getCreatedAt(),
                                         userAccount.getUpdatedAt());
     }
+
+    @Transactional
+    public UserInfo.AccountInfo chargeBalanceWithLock(Long userId, Long balance) {
+        User user = userService.getUser(userId);
+        UserAccount userAccount = userAccountService.chargeBalanceWithLock(new UserAccountCommand.Action(userId, balance));
+        return new UserInfo.AccountInfo(userAccount.getAccountId(),
+                                        user.getUserId(),
+                                        user.getUsername(),
+                                        userAccount.getBalance(),
+                                        userAccount.getCreatedAt(),
+                                        userAccount.getUpdatedAt());
+    }
 }

--- a/src/test/java/org/lowell/concert/application/user/UserFacadeConcurrencyTest.java
+++ b/src/test/java/org/lowell/concert/application/user/UserFacadeConcurrencyTest.java
@@ -1,0 +1,85 @@
+package org.lowell.concert.application.user;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.lowell.concert.application.support.DatabaseCleanUp;
+import org.lowell.concert.domain.user.model.User;
+import org.lowell.concert.domain.user.model.UserAccount;
+import org.lowell.concert.infra.db.user.repository.UserAccountJpaRepository;
+import org.lowell.concert.infra.db.user.repository.UserJpaRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@SpringBootTest
+public class UserFacadeConcurrencyTest {
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    UserAccountJpaRepository userAccountJpaRepository;
+
+    @Autowired
+    private UserFacade userFacade;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.execute();
+    }
+
+    @DisplayName("비관적 락을 통해 포인트 충전을 10회 진행할 경우 10,000원이 충전되어야 한다.")
+    @Test
+    void balanceIs1000WhenMultipleChargingToSameAccount() throws InterruptedException {
+        // given
+        User test1 = userJpaRepository.save(User.builder()
+                                                .username("test1")
+                                                .build());
+        userAccountJpaRepository.save(UserAccount.builder()
+                                                 .userId(test1.getUserId())
+                                                 .balance(0L)
+                                                 .build());
+        int threadCount = 10;
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger success = new AtomicInteger(0);
+        AtomicInteger failed = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    userFacade.chargeBalanceWithLock(test1.getUserId(), 1000L);
+                    success.incrementAndGet();
+                } catch (Exception e) {
+                    log.error("## error : {}", e.getLocalizedMessage());
+                    failed.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        userAccountJpaRepository.findByUserId(test1.getUserId())
+                                .ifPresent(userAccount -> {
+                                    assertThat(userAccount.getBalance()).isEqualTo(10000L);
+                                });
+        assertThat(success.get()).isEqualTo(10);
+    }
+}


### PR DESCRIPTION
## 작업 내용


* 선택 방식: 비관적 락
레디스를 활용한 락보다는 DB 락에 대해 더 잘 알고 있어 자신감을 갖고 코드를 작성할 수 있었기 때문입니다.
특히 redis setNx에서 leaseTime이나 RLock의 waitTime 설정을 어떻게 해야 할지 명확히 이해되지 않아, 여러 차례 조정하며 테스트를 통과시키는 과정에서 어려움이 있었습니다. 잘 모르는 상태에서 구현을 해서 선뜻 적용하기가 망설여졌습니다.
비록 현재 적용하지는 않았지만, Redis 락 관리 로직은 AOP로 분리하여 구현 중에 있으며, 추후 통합 테스트와 성능 테스트를 통해 검토할 계획입니다.
-------

비관적 락에 대한 통합 테스트 부분을 이전에 작성 및 커밋 메시지를 잘못 올려서 각 테스트에 대해 파일 링크로 걸었습니다.
양해 부탁드립니다.

* 콘서트 좌석 예약 (https://github.com/saintnun150/hhplus-concert-reservation-server/blob/step12-test/src/test/java/org/lowell/concert/application/concert/integration/ConcertFacadeTest.java)

* 콘서트 예약 결제 (https://github.com/saintnun150/hhplus-concert-reservation-server/blob/step12-test/src/test/java/org/lowell/concert/application/payment/integration/PaymentConcurrencyTest.java)

* 사용자 잔액 충전 (https://github.com/saintnun150/hhplus-concert-reservation-server/blob/step12-test/src/test/java/org/lowell/concert/application/user/UserFacadeConcurrencyTest.java)

----

## 궁금한 점

* redis setNx에서 leaseTime이나 RLock에서 waitTime에 대한 설정을 어떻게 가져가야할 지 궁금합니다.
일단 해당 비즈니스 로직 수행 시간은 기본적으로 확인하여 조절해야할 것 같아서 그 부분만 고려된 상태인데
다른 고려사항이 있을까요?

----


