### PR TITLE
Step14 대기열 Redis 구현

### DIFF
--- a/src/main/java/org/lowell/concert/application/waitingqueue/WaitingQueueFacade.java
+++ b/src/main/java/org/lowell/concert/application/waitingqueue/WaitingQueueFacade.java
@@ -34,6 +34,7 @@ public class WaitingQueueFacade {
         return new WaitingQueueInfo.Get(queueTokenInfo.getToken(),
                                         queueTokenInfo.getTokenStatus(),
                                         queueTokenInfo.getExpiresAt(),
+                                        queueTokenInfo.getTokenStatus() == TokenStatus.ACTIVATE ? 0L : null,
                                         queueTokenInfo.getTokenStatus() == TokenStatus.ACTIVATE ? 0L : null);
     }
 
@@ -42,13 +43,8 @@ public class WaitingQueueFacade {
     }
 
     @Transactional
-    public void activateReadyWaitingQueues() {
-        LocalDateTime now = LocalDateTime.now();
-        waitingQueueService.activateWaitingToken(
-                new WaitingQueueCommand.UpdateBatch(null,
-                                                    TokenStatus.ACTIVATE,
-                                                    now,
-                                                    now.plusMinutes(ConcertPolicy.EXPIRED_QUEUE_MINUTES)));
+    public void activateReadyWaitingQueues(WaitingQueueQuery.GetQueues query) {
+        waitingQueueService.activateWaitingToken(query);
     }
 
     public void ensureQueueTokenIsActiveAndValid(String token, LocalDateTime now) {

--- a/src/main/java/org/lowell/concert/application/waitingqueue/WaitingQueueInfo.java
+++ b/src/main/java/org/lowell/concert/application/waitingqueue/WaitingQueueInfo.java
@@ -2,7 +2,6 @@ package org.lowell.concert.application.waitingqueue;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.lowell.concert.domain.waitingqueue.model.TokenStatus;
 
 import java.time.LocalDateTime;
@@ -16,6 +15,7 @@ public class WaitingQueueInfo {
         private final TokenStatus tokenStatus;
         private final LocalDateTime expiresAt;
         private final Long order;
+        private final Long waitingTime;
     }
 
 }

--- a/src/main/java/org/lowell/concert/application/waitingqueue/WaitingQueueScheduler.java
+++ b/src/main/java/org/lowell/concert/application/waitingqueue/WaitingQueueScheduler.java
@@ -4,8 +4,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.lowell.concert.application.common.exception.ApplicationError;
 import org.lowell.concert.application.common.exception.ApplicationException;
+import org.lowell.concert.domain.concert.ConcertPolicy;
+import org.lowell.concert.domain.waitingqueue.dto.WaitingQueueQuery;
+import org.lowell.concert.domain.waitingqueue.model.TokenStatus;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
 
 @Slf4j
 @Component
@@ -16,7 +21,10 @@ public class WaitingQueueScheduler {
     @Scheduled(fixedRate = 1000 * 60)
     public void activateReadyTokens() {
         try {
-            waitingQueueFacade.activateReadyWaitingQueues();
+            LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(ConcertPolicy.EXPIRED_QUEUE_MINUTES);
+            waitingQueueFacade.activateReadyWaitingQueues(new WaitingQueueQuery.GetQueues(TokenStatus.WAITING,
+                                                                                          expiresAt,
+                                                                                          ConcertPolicy.ACTIVATE_QUEUE_SIZE));
         } catch (Exception e) {
             log.error("## Error occurred while activating ready tokens", e);
             throw ApplicationException.create(ApplicationError.INTERNAL_SERVER);

--- a/src/main/java/org/lowell/concert/domain/common/util/UUIDGenerator.java
+++ b/src/main/java/org/lowell/concert/domain/common/util/UUIDGenerator.java
@@ -1,0 +1,16 @@
+package org.lowell.concert.domain.common.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Slf4j
+@Component
+public class UUIDGenerator {
+    public static String generateTimestampUUID() {
+        long timestamp = System.currentTimeMillis();
+        String uniqueId = UUID.randomUUID().toString().replace("-", "").substring(0, 17);
+        return timestamp + uniqueId;
+    }
+}

--- a/src/main/java/org/lowell/concert/domain/concert/ConcertPolicy.java
+++ b/src/main/java/org/lowell/concert/domain/concert/ConcertPolicy.java
@@ -1,6 +1,12 @@
 package org.lowell.concert.domain.concert;
 
+import java.util.concurrent.TimeUnit;
+
 public class ConcertPolicy {
+    public static final Long ACTIVATE_QUEUE_INTERVAL = 5L;
+    public static final TimeUnit ACTIVATE_QUEUE_TIME_UNIT = TimeUnit.SECONDS;
+    public static final int ACTIVATE_QUEUE_CAPACITY = 50;
+    public static final Long ACTIVATE_QUEUE_SIZE = 50L;
     public static int TEMP_RESERVED_SEAT_MINUTES = 5;
     public static long EXPIRED_QUEUE_MINUTES = 10;
 }

--- a/src/main/java/org/lowell/concert/domain/waitingqueue/dto/WaitingQueueCommand.java
+++ b/src/main/java/org/lowell/concert/domain/waitingqueue/dto/WaitingQueueCommand.java
@@ -8,6 +8,6 @@ import java.util.List;
 public class WaitingQueueCommand {
     public record CreateToken(String token, TokenStatus status, LocalDateTime expiresAt) {
     }
-    public record UpdateBatch(List<Long> tokenIds, TokenStatus status, LocalDateTime updatedAt, LocalDateTime expiresAt) { }
+    public record UpdateBatch(Long count) { }
     public record ExpireToken(String token, LocalDateTime now) { }
 }

--- a/src/main/java/org/lowell/concert/domain/waitingqueue/dto/WaitingQueueQuery.java
+++ b/src/main/java/org/lowell/concert/domain/waitingqueue/dto/WaitingQueueQuery.java
@@ -17,5 +17,5 @@ public class WaitingQueueQuery {
     }
     public record GetOrder(String token, TokenStatus tokenStatus) { }
     public record CheckQueueActivation(String token, LocalDateTime now) {}
-    public record GetQueues(TokenStatus tokenStatus, long size) { }
+    public record GetQueues(TokenStatus tokenStatus, LocalDateTime expiresAt, long size) { }
 }

--- a/src/main/java/org/lowell/concert/domain/waitingqueue/exception/WaitingQueueError.java
+++ b/src/main/java/org/lowell/concert/domain/waitingqueue/exception/WaitingQueueError.java
@@ -18,7 +18,10 @@ public enum WaitingQueueError implements DomainError {
     EMPTY_TOKENS(ErrorCode.BAD_REQUEST,  "Tokens is empty", LogLevel.DEBUG),
     EMPTY_TOKEN_IDS(ErrorCode.BAD_REQUEST,  "Token IDs is empty", LogLevel.DEBUG),
     INVALID_TOKEN_EXPIRES_DATE(ErrorCode.VALIDATION,  "Token expires date is unspecified value", LogLevel.WARN),
-    EMPTY_TOKEN_ID(ErrorCode.BAD_REQUEST,  "Token id is not exist", LogLevel.DEBUG),;
+    EMPTY_TOKEN_ID(ErrorCode.BAD_REQUEST,  "Token id is not exist", LogLevel.DEBUG),
+    FAILED_CREATE_QUEUE(ErrorCode.INTERNAL_SERVER,  "Failed to create queue", LogLevel.ERROR),
+    FAILED_CREATE_DUPLICATE_QUEUE(ErrorCode.BAD_REQUEST,  "Failed to create duplicate queue", LogLevel.WARN),
+    ;
 
     private final ErrorCode code;
     private final String message;

--- a/src/main/java/org/lowell/concert/domain/waitingqueue/repository/WaitingQueueProvider.java
+++ b/src/main/java/org/lowell/concert/domain/waitingqueue/repository/WaitingQueueProvider.java
@@ -1,0 +1,5 @@
+package org.lowell.concert.domain.waitingqueue.repository;
+
+public interface WaitingQueueProvider {
+    WaitingQueueRepository getWaitingQueueRepository(String type);
+}

--- a/src/main/java/org/lowell/concert/domain/waitingqueue/repository/WaitingQueueRepository.java
+++ b/src/main/java/org/lowell/concert/domain/waitingqueue/repository/WaitingQueueRepository.java
@@ -13,9 +13,9 @@ public interface WaitingQueueRepository {
     WaitingQueueTokenInfo createQueueToken(WaitingQueueCommand.CreateToken command);
     Optional<WaitingQueueTokenInfo> findQueueToken(WaitingQueueQuery.GetToken query);
     Long findWaitingTokenOrder(WaitingQueueQuery.GetOrder query);
-    Long findActivateQueueTokenCount(TokenStatus tokenStatus);
+    Long findTokenCount(TokenStatus tokenStatus);
     List<WaitingQueueToken> findQueuesByStatusAndSize(WaitingQueueQuery.GetQueues query);
     void expireQueueToken(WaitingQueueCommand.ExpireToken command);
-    void updateAll(WaitingQueueCommand.UpdateBatch command);
-    void deleteAll();
+    void activateWaitingToken(WaitingQueueQuery.GetQueues query);
+    boolean existsActivateToken(String token);
 }

--- a/src/main/java/org/lowell/concert/infra/redis/support/RedisRepository.java
+++ b/src/main/java/org/lowell/concert/infra/redis/support/RedisRepository.java
@@ -2,8 +2,10 @@ package org.lowell.concert.infra.redis.support;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Repository;
 
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 @Repository
@@ -11,11 +13,42 @@ import java.util.concurrent.TimeUnit;
 public class RedisRepository {
     private final RedisTemplate<String, Object> redisTemplate;
 
-    public Boolean setIfAbsent(String key, String value, Long leaseTime, TimeUnit timeUnit){
+    public Boolean addIfAbsent(String key, String value, Long leaseTime, TimeUnit timeUnit){
         return redisTemplate.opsForValue().setIfAbsent(key, value, leaseTime, timeUnit);
     }
 
-    public Boolean delete(String key){
+    public Boolean deleteKey(String key){
         return redisTemplate.delete(key);
+    }
+    public Boolean existsKey(String key) {
+        return redisTemplate.hasKey(key);
+    }
+
+    public Boolean addZSet(String key, String value, double score){
+        return redisTemplate.opsForZSet().add(key, value, score);
+    }
+
+    public Boolean addZSetIfAbsent(String key, String value, double score){
+        return redisTemplate.opsForZSet().addIfAbsent(key, value, score);
+    }
+
+    public ZSetOperations<String, Object> getZSetOps() {
+        return redisTemplate.opsForZSet();
+    }
+
+    public Set<Object> getZSetRange(String key, long start, long end) {
+        return this.getZSetOps().range(key, start, end);
+    }
+
+    public Long getZSetRank(String key, Object value) {
+        return this.getZSetOps().rank(key, value);
+    }
+
+    public Long getZSetSize(String key) {
+        return this.getZSetOps().zCard(key);
+    }
+
+    public Set<ZSetOperations.TypedTuple<Object>> zPopMin(String key, long count) {
+        return this.getZSetOps().popMin(key, count);
     }
 }

--- a/src/main/java/org/lowell/concert/infra/redis/support/RedisRepository.java
+++ b/src/main/java/org/lowell/concert/infra/redis/support/RedisRepository.java
@@ -51,4 +51,8 @@ public class RedisRepository {
     public Set<ZSetOperations.TypedTuple<Object>> zPopMin(String key, long count) {
         return this.getZSetOps().popMin(key, count);
     }
+
+    public Object getValue(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
 }

--- a/src/main/java/org/lowell/concert/infra/redis/support/RedisSimpleLockManager.java
+++ b/src/main/java/org/lowell/concert/infra/redis/support/RedisSimpleLockManager.java
@@ -14,11 +14,11 @@ public class RedisSimpleLockManager implements LockManager {
     @Override
     public Boolean tryLock(String lockKey, Long waitTime, Long leaseTime, TimeUnit timeUnit) {
         long lockValue = System.currentTimeMillis() + timeUnit.toMillis(waitTime);
-        return redisRepository.setIfAbsent(lockKey, Long.toString(lockValue), leaseTime, timeUnit);
+        return redisRepository.addIfAbsent(lockKey, Long.toString(lockValue), leaseTime, timeUnit);
     }
 
     @Override
     public void unlock(String lockKey) {
-        redisRepository.delete(lockKey);
+        redisRepository.deleteKey(lockKey);
     }
 }

--- a/src/main/java/org/lowell/concert/infra/redis/support/RedisSpinLockManager.java
+++ b/src/main/java/org/lowell/concert/infra/redis/support/RedisSpinLockManager.java
@@ -18,7 +18,7 @@ public class RedisSpinLockManager implements LockManager {
     public Boolean tryLock(String lockKey, Long waitTime, Long leaseTime, TimeUnit timeUnit) {
         long retryTime = System.currentTimeMillis() + timeUnit.toMillis(waitTime);
         while (true) {
-            if (redisRepository.setIfAbsent(lockKey, "", leaseTime, timeUnit)) {
+            if (redisRepository.addIfAbsent(lockKey, "", leaseTime, timeUnit)) {
                 return true;
             }
             try {
@@ -33,6 +33,6 @@ public class RedisSpinLockManager implements LockManager {
 
     @Override
     public void unlock(String lockKey) {
-        redisRepository.delete(lockKey);
+        redisRepository.deleteKey(lockKey);
     }
 }

--- a/src/main/java/org/lowell/concert/infra/redis/waitingqueue/WaitingQueueRedisRepositoryImpl.java
+++ b/src/main/java/org/lowell/concert/infra/redis/waitingqueue/WaitingQueueRedisRepositoryImpl.java
@@ -1,0 +1,105 @@
+package org.lowell.concert.infra.redis.waitingqueue;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.lowell.concert.domain.concert.ConcertPolicy;
+import org.lowell.concert.domain.waitingqueue.dto.WaitingQueueCommand;
+import org.lowell.concert.domain.waitingqueue.dto.WaitingQueueQuery;
+import org.lowell.concert.domain.waitingqueue.model.TokenStatus;
+import org.lowell.concert.domain.waitingqueue.model.WaitingQueueToken;
+import org.lowell.concert.domain.waitingqueue.model.WaitingQueueTokenInfo;
+import org.lowell.concert.domain.waitingqueue.repository.WaitingQueueRepository;
+import org.lowell.concert.infra.redis.support.RedisRepository;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class WaitingQueueRedisRepositoryImpl implements WaitingQueueRepository {
+    private final RedisRepository redisRepository;
+    private static final String WAITING_QUEUE_KEY_PREFIX = "waitingQueue";
+    private static final String ACTIVATE_QUEUE_KEY_PREFIX = "activatedToken";
+
+    @Override
+    public WaitingQueueTokenInfo createQueueToken(WaitingQueueCommand.CreateToken command) {
+        if (command.status() == TokenStatus.ACTIVATE) {
+            redisRepository.addIfAbsent(command.token(),
+                                        command.expiresAt().toString(),
+                                        ConcertPolicy.EXPIRED_QUEUE_MINUTES,
+                                        TimeUnit.MINUTES);
+        } else {
+            redisRepository.addZSetIfAbsent(WAITING_QUEUE_KEY_PREFIX,
+                                            command.token(),
+                                            System.currentTimeMillis());
+        }
+        return new WaitingQueueTokenInfo(command.token(),
+                                         command.status(),
+                                         command.expiresAt());
+    }
+
+    @Override
+    public Optional<WaitingQueueTokenInfo> findQueueToken(WaitingQueueQuery.GetToken query) {
+        Long waitRank = redisRepository.getZSetRank(WAITING_QUEUE_KEY_PREFIX, query.token());
+        if (waitRank != null) {
+            return Optional.of(new WaitingQueueTokenInfo(query.token(),
+                                                         TokenStatus.WAITING,
+                                                         null));
+        }
+
+        return Optional.ofNullable(redisRepository.getValue(query.token()))
+                       .map(value -> LocalDateTime.parse((String) value, DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                       .map(expiresAt -> new WaitingQueueTokenInfo(query.token(),
+                                                                   TokenStatus.ACTIVATE,
+                                                                   expiresAt));
+    }
+
+    @Override
+    public Long findWaitingTokenOrder(WaitingQueueQuery.GetOrder query) {
+        return redisRepository.getZSetRank(WAITING_QUEUE_KEY_PREFIX, query.token());
+    }
+
+    @Override
+    public void activateWaitingToken(WaitingQueueQuery.GetQueues query) {
+        Set<ZSetOperations.TypedTuple<Object>> tokens = redisRepository.zPopMin(WAITING_QUEUE_KEY_PREFIX, query.size());
+        for (ZSetOperations.TypedTuple<Object> tuple : tokens) {
+            Object token = tuple.getValue();
+            String key = ACTIVATE_QUEUE_KEY_PREFIX + token.toString();
+            redisRepository.addIfAbsent(key,
+                                        query.expiresAt().toString(),
+                                        ConcertPolicy.EXPIRED_QUEUE_MINUTES,
+                                        TimeUnit.MINUTES);
+        }
+    }
+
+
+    @Override
+    public boolean existsActivateToken(String token) {
+        return redisRepository.existsKey(token);
+    }
+
+    @Override
+    public void expireQueueToken(WaitingQueueCommand.ExpireToken command) {
+        redisRepository.deleteKey(command.token());
+    }
+
+    @Override
+    public Long findTokenCount(TokenStatus tokenStatus) {
+        if (tokenStatus == TokenStatus.WAITING) {
+            return redisRepository.getZSetSize(WAITING_QUEUE_KEY_PREFIX);
+        }
+        return null;
+    }
+
+    @Override
+    public List<WaitingQueueToken> findQueuesByStatusAndSize(WaitingQueueQuery.GetQueues query) {
+        return List.of();
+    }
+}

--- a/src/main/java/org/lowell/concert/infra/support/WaitingQueueProviderImpl.java
+++ b/src/main/java/org/lowell/concert/infra/support/WaitingQueueProviderImpl.java
@@ -1,0 +1,24 @@
+package org.lowell.concert.infra.support;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.lowell.concert.domain.waitingqueue.repository.WaitingQueueProvider;
+import org.lowell.concert.domain.waitingqueue.repository.WaitingQueueRepository;
+import org.lowell.concert.infra.db.waitingqueue.WaitingQueueRepositoryImpl;
+import org.lowell.concert.infra.redis.waitingqueue.WaitingQueueRedisRepositoryImpl;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WaitingQueueProviderImpl implements WaitingQueueProvider {
+    private final WaitingQueueRepositoryImpl waitingQueueRepository;
+    private final WaitingQueueRedisRepositoryImpl waitingQueueRedisRepository;
+
+    public WaitingQueueRepository getWaitingQueueRepository(String type) {
+        if (type.equals("db")) {
+            return waitingQueueRepository;
+        }
+        return waitingQueueRedisRepository;
+    }
+}

--- a/src/test/java/org/lowell/concert/application/payment/integration/PaymentConcurrencyTest.java
+++ b/src/test/java/org/lowell/concert/application/payment/integration/PaymentConcurrencyTest.java
@@ -23,6 +23,8 @@ import org.lowell.concert.infra.db.user.repository.UserJpaRepository;
 import org.lowell.concert.infra.db.waitingqueue.WaitingQueueJpaRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 
 import java.time.LocalDateTime;
 import java.util.concurrent.CountDownLatch;
@@ -55,6 +57,11 @@ public class PaymentConcurrencyTest {
     @AfterEach
     void tearDown() {
         databaseCleanUp.execute();
+    }
+
+    @DynamicPropertySource
+    static void setProperties(DynamicPropertyRegistry registry) {
+        registry.add("waiting-queue.type", () -> "db");
     }
 
     @DisplayName("같은 예약 건에 대해 결제 요청이 동시에 들어오면 하나만 성공한다.")

--- a/src/test/java/org/lowell/concert/application/payment/integration/PaymentFacadeTest.java
+++ b/src/test/java/org/lowell/concert/application/payment/integration/PaymentFacadeTest.java
@@ -25,6 +25,8 @@ import org.lowell.concert.infra.db.user.repository.UserJpaRepository;
 import org.lowell.concert.infra.db.waitingqueue.WaitingQueueJpaRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 
 import java.time.LocalDateTime;
 import java.util.logging.Logger;
@@ -50,6 +52,11 @@ public class PaymentFacadeTest {
 
     @Autowired
     private DatabaseCleanUp databaseCleanUp;
+
+    @DynamicPropertySource
+    static void setProperties(DynamicPropertyRegistry registry) {
+        registry.add("waiting-queue.type", () -> "db");
+    }
 
     @AfterEach
     void tearDown() {

--- a/src/test/java/org/lowell/concert/application/support/DatabaseCleanUp.java
+++ b/src/test/java/org/lowell/concert/application/support/DatabaseCleanUp.java
@@ -6,11 +6,15 @@ import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Table;
 import jakarta.persistence.metamodel.EntityType;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 @Component
 //@ActiveProfiles("test")
@@ -20,6 +24,9 @@ public class DatabaseCleanUp implements InitializingBean {
     private EntityManager entityManager;
 
     private List<String> tableNames = new ArrayList<>();
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
 
     @Override
     public void afterPropertiesSet() {
@@ -45,5 +52,12 @@ public class DatabaseCleanUp implements InitializingBean {
         }
 
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+
+    public void cleanRedisData() {
+        Set<String> keys = redisTemplate.keys("*");
+        if (!CollectionUtils.isEmpty(keys)) {
+            redisTemplate.delete(keys);
+        }
     }
 }

--- a/src/test/java/org/lowell/concert/domain/waitingqueue/integration/WaitingQueueTokenIntegrationTest.java
+++ b/src/test/java/org/lowell/concert/domain/waitingqueue/integration/WaitingQueueTokenIntegrationTest.java
@@ -14,6 +14,8 @@ import org.lowell.concert.domain.waitingqueue.model.WaitingQueueTokenInfo;
 import org.lowell.concert.domain.waitingqueue.service.WaitingQueueService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -28,6 +30,11 @@ public class WaitingQueueTokenIntegrationTest {
 
     @Autowired
     private DatabaseCleanUp databaseCleanUp;
+
+    @DynamicPropertySource
+    static void setProperties(DynamicPropertyRegistry registry) {
+        registry.add("waiting-queue.type", () -> "db");
+    }
 
     @AfterEach
     void tearDown() {

--- a/src/test/java/org/lowell/concert/domain/waitingqueue/integration/WaitingQueueTokenRedisIntegrationTest.java
+++ b/src/test/java/org/lowell/concert/domain/waitingqueue/integration/WaitingQueueTokenRedisIntegrationTest.java
@@ -1,0 +1,115 @@
+package org.lowell.concert.domain.waitingqueue.integration;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.lowell.concert.application.support.DatabaseCleanUp;
+import org.lowell.concert.domain.common.exception.DomainException;
+import org.lowell.concert.domain.common.util.UUIDGenerator;
+import org.lowell.concert.domain.concert.ConcertPolicy;
+import org.lowell.concert.domain.waitingqueue.dto.WaitingQueueCommand;
+import org.lowell.concert.domain.waitingqueue.dto.WaitingQueueQuery;
+import org.lowell.concert.domain.waitingqueue.exception.WaitingQueueError;
+import org.lowell.concert.domain.waitingqueue.model.TokenStatus;
+import org.lowell.concert.domain.waitingqueue.model.WaitingQueueTokenInfo;
+import org.lowell.concert.domain.waitingqueue.service.WaitingQueueService;
+import org.lowell.concert.infra.redis.waitingqueue.WaitingQueueRedisRepositoryImpl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Slf4j
+@SpringBootTest
+public class WaitingQueueTokenRedisIntegrationTest {
+
+    @Autowired
+    private WaitingQueueService waitingQueueService;
+
+    @Autowired
+    private WaitingQueueRedisRepositoryImpl waitingQueueRedisRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @DynamicPropertySource
+    static void setProperties(DynamicPropertyRegistry registry) {
+        registry.add("waiting-queue.type", () -> "redis");
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.cleanRedisData();
+    }
+
+    @DisplayName("주어진 token값에 대한 대기열이 ZSET 생성된다.")
+    @Test
+    void createWaitingQueue() {
+        // given
+        String token = UUIDGenerator.generateTimestampUUID();
+        WaitingQueueCommand.CreateToken command = new WaitingQueueCommand.CreateToken(token, TokenStatus.WAITING, null);
+        WaitingQueueTokenInfo waitingQueueTokenInfo = waitingQueueService.createQueueToken(command);
+        assertThat(waitingQueueTokenInfo.getToken()).isEqualTo(token);
+    }
+
+    @DisplayName("주어진 token 값에 대한 대기열 조회")
+    @Test
+    void getWaitingQueue() {
+        // given
+        String token = UUIDGenerator.generateTimestampUUID();
+        WaitingQueueCommand.CreateToken command = new WaitingQueueCommand.CreateToken(token, TokenStatus.WAITING, null);
+        waitingQueueService.createQueueToken(command);
+        // when
+        WaitingQueueQuery.GetToken query = new WaitingQueueQuery.GetToken(token);
+        WaitingQueueTokenInfo getTokenInfo = waitingQueueService.getQueueToken(query);
+        // then
+        assertThat(getTokenInfo.getToken()).isEqualTo(token);
+        assertThat(getTokenInfo.getTokenStatus()).isEqualTo(command.status());
+    }
+
+    @DisplayName("주어진 token 값에 대한 순서 조회 시 활성화 되었지만 이미 만료된 토큰일 경우 예외가 발생한다.")
+    @Test
+    void getWaitingQueueOrderWhenTokenIsExpired() {
+        // given
+        String token = UUIDGenerator.generateTimestampUUID();
+        WaitingQueueCommand.CreateToken command = new WaitingQueueCommand.CreateToken(token, TokenStatus.ACTIVATE, LocalDateTime.now().minusMinutes(20L));
+        waitingQueueService.createQueueToken(command);
+        // when
+        WaitingQueueQuery.GetToken query = new WaitingQueueQuery.GetToken(token);
+        // then
+        assertThatThrownBy(() -> waitingQueueService.getQueueTokenOrder(query))
+                .isInstanceOfSatisfying(DomainException.class, ex -> {
+                    assertThat(ex.getDomainError()).isEqualTo(WaitingQueueError.TOKEN_EXPIRED);
+                });
+    }
+
+    @DisplayName("대기열에 있는 토큰이 N개 일 때 M개 만큼 활성화되면 남은 대기열 토큰은 N-M개가 된다.")
+    @Test
+    void activateWaitingToken() {
+        // given
+
+        int waitingTokenSize = 100;
+        long activateTokenSize = 40;
+        for (int i = 0; i < waitingTokenSize; i++) {
+            String token = UUIDGenerator.generateTimestampUUID();
+            WaitingQueueCommand.CreateToken command = new WaitingQueueCommand.CreateToken(token, TokenStatus.WAITING, null);
+            waitingQueueService.createQueueToken(command);
+        }
+
+        LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(ConcertPolicy.EXPIRED_QUEUE_MINUTES);
+
+        // when
+        waitingQueueRedisRepository.activateWaitingToken(new WaitingQueueQuery.GetQueues(null, expiresAt, 40));
+        // then
+        Long tokenCount = waitingQueueRedisRepository.findTokenCount(TokenStatus.WAITING);
+        assertThat(tokenCount).isEqualTo(waitingTokenSize - activateTokenSize);
+    }
+
+
+}

--- a/src/test/java/org/lowell/concert/infra/RedisDataStructureTest.java
+++ b/src/test/java/org/lowell/concert/infra/RedisDataStructureTest.java
@@ -1,0 +1,115 @@
+package org.lowell.concert.infra;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.lowell.concert.application.support.DatabaseCleanUp;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@SpringBootTest
+public class RedisDataStructureTest {
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.cleanRedisData();
+    }
+
+    @DisplayName("Redis sorted set 저장 테스트")
+    @Test
+    void setRedisSortedSet() {
+        // given
+        String key = "test";
+
+        // when
+        for (int i = 1; i <= 10; i++) {
+            redisTemplate.opsForZSet().add(key, StringUtils.replace(UUID.randomUUID().toString(), "\"", " "), i);
+        }
+
+        // then
+        assertThat(redisTemplate.opsForZSet().size(key)).isEqualTo(10);
+    }
+
+    @DisplayName("Redis sorted set 삭제 테스트")
+    @Test
+    void deleteRedisSortedSet() {
+        // given
+        String key = "test";
+        String value = "test22";
+        // when
+        redisTemplate.opsForZSet()
+                     .add(key, value, 1);
+        redisTemplate.opsForZSet()
+                     .remove(key, value);
+        // then
+        assertThat(redisTemplate.opsForZSet().score(key, value)).isNull();
+    }
+
+    @DisplayName("test라는 key의 sorted set에 value 존재 여부 및 순서 확인")
+    @Test
+    void checkRedisSortedSetAndRank() throws InterruptedException {
+        // given
+        String key = "test";
+
+        List<String> values = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            String value = UUID.randomUUID().toString();
+            values.add(value);
+            long score = System.currentTimeMillis();
+            Thread.sleep(1);
+            redisTemplate.opsForZSet().add(key, value, score);
+        }
+        // when
+        Long rank = redisTemplate.opsForZSet()
+                                 .rank(key, values.get(2));
+
+        Boolean isMember = rank != null;
+        // then
+        assertThat(rank).isNotNull().isEqualTo(2L);
+        assertThat(isMember).isTrue();
+    }
+
+    @DisplayName("test라는 key의 sorted set에 0부터 1까지의 순서에 해당하는 value를 꺼내와서 각각 String 자료구조에 만료 시간은 10분으로 redis에 저장")
+    @Test
+    void saveAndRemoveTop4ValuesFromSortedSetAsStringWithExpiry() throws InterruptedException {
+        // given
+        String key = "test";
+        // when
+        List<String> values = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            String value = UUID.randomUUID().toString();
+            values.add(value);
+            long score = System.currentTimeMillis();
+            Thread.sleep(1);
+            redisTemplate.opsForZSet().add(key, value, score);
+        }
+
+        Set<Object> range = redisTemplate.opsForZSet()
+                                         .range(key, 0L, 1L);
+
+        for (Object value : range) {
+            redisTemplate.opsForValue().set(value.toString(), value.toString(), 10L, TimeUnit.MINUTES);
+            redisTemplate.opsForZSet().remove(key, value);
+        }
+        // then
+        assertThat(redisTemplate.opsForZSet().zCard(key)).isEqualTo(8);
+        assertThat(redisTemplate.opsForValue().get(values.get(0))).isNotNull();
+        assertThat(redisTemplate.opsForValue().get(values.get(1))).isNotNull();
+    }
+
+}


### PR DESCRIPTION
## 작업 내용

* 대기열 JPA repository 구현체와 분기처리를 위한 클래스 생성 (https://github.com/saintnun150/hhplus-concert-reservation-server/pull/26/commits/6feaae35aeb281cbc6c7ee9278bc0d4b11f85ac8)
* Redis 대기열 테스트 코드 작성 (https://github.com/saintnun150/hhplus-concert-reservation-server/pull/26/commits/f7e3f4f15cc4cece0fbeec67e5f179d8b4d021d9)

-----
## 궁금한 점
기존 JPA repository도 사용할 수 있게 중간에 provider라는 클래스를 작성했습니다. db인지 redis인지 타입을 통해 해당 repository를 가져오게 처리했습니다. 다만 infra 레이어에 첫번째 depth를 db, redis 로 나눠놔서 해당 클래스의 위치가 애매해졌고, 결국 infra/support/ 하위에 위치시켰습니다.
* 이처럼 여러 구현체가 존재할 경우 위와 같이 하는게 맞을까요?
* 공통 유틸이나 infra 인터페이스 같은 것에 대해 위치가 계속 애매합니다.  클렌징 해야할 부분이 있다면 말씀 부탁드립니다!


